### PR TITLE
Allow dev version of packages

### DIFF
--- a/Command/SwitchPackageToGitClone.php
+++ b/Command/SwitchPackageToGitClone.php
@@ -214,7 +214,7 @@ class SwitchPackageToGitClone extends BaseCommand {
     else {
       $output->writeln("Installing {$package_name} from the git clone path repository.");
 
-      exec("composer require {$package_name}");
+      exec("composer require {$package_name}:@dev");
     }
 
     // TODO! Check Composer didn't output any errors!


### PR DESCRIPTION
The stable version ```drupal/recommended-project``` have ```minimum-stability``` set to ```stable```. Some modules only have dev releases. It`s not possible to add them with the command. I think its makes sense to override the stability during installation.